### PR TITLE
feat: add necessary adjustments to work with engrid

### DIFF
--- a/src/sass/frequency.scss
+++ b/src/sass/frequency.scss
@@ -56,6 +56,9 @@
         border: solid 1px #d2d2d2;
         background-color: #f7f7fa;
         color: #344857;
+        &::before {
+          display: none;
+        }
         .monthly-icon {
           width: 28px;
           height: 22px;

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -51,6 +51,7 @@ body[data-item-selected="true"] #en-shopping-cart {
 #en-shopping-cart {
   .en__component--advrow {
     max-width: 100%;
+    min-height: unset;
   }
   @import "./header.scss";
   @import "./frequency.scss";
@@ -67,4 +68,14 @@ body[data-item-selected="true"] #en-shopping-cart {
 // This is for PETA Germany only, break wording for the headings in the cards
 html[lang="de-DE"] {
   @import "./peta-germany.scss";
+}
+
+.flex {
+  display: flex !important;
+}
+
+.form-container {
+  max-width: 1040px !important;
+  margin: 0 auto !important;
+  column-gap: 40px;
 }


### PR DESCRIPTION
This PR adds necessary adjustments to ensure compatibility with Engrid imports.

- Unsets Advanced Row `min-height`, which is defaulted to 100vh in Engrid.

- Hides the `::before` pseudo-element added to input labels by Engrid, ensuring the One-time/Monthly radio buttons display as expected.

- Adds a custom `.flex` class to convert components that are incompatible with "grid" layouts to "flex" layouts (applied to sc-frequency, sc-info, and form field containers in Page Builder).

- Adds a custom `.form-container` class with styles to ensure the form block displays prettily.